### PR TITLE
Add telemetry cache logic

### DIFF
--- a/azure-ai-speech-toolkit/package.json
+++ b/azure-ai-speech-toolkit/package.json
@@ -213,8 +213,8 @@
   "dependencies": {
     "@vscode/codicons": "^0.0.36",
     "@vscode/extension-telemetry": "^0.6.2",
+    "crypto": "^1.0.1",
     "dompurify": "^3.1.6",
-    "js-yaml": "^4.1.0",
     "mermaid": "^11.1.0"
   }
 }

--- a/azure-ai-speech-toolkit/src/extension.ts
+++ b/azure-ai-speech-toolkit/src/extension.ts
@@ -10,19 +10,17 @@ import { AzureAccountManager } from './common/azureLogin';
 import TreeViewManagerInstance from "./treeview/treeViewManager";
 import { isSpeechResourceSeleted } from './utils';
 import resourceTreeViewProvider from './treeview/resourceTreeViewProvider';
-import TelemetryReporter from '@vscode/extension-telemetry';
-import * as extensionPackage from "../package.json";
+import { ExtTelemetry } from './telemetry/extTelemetry';
 
 export let VS_CODE_UI: VSCodeUI;
-export let telemetryReporter: TelemetryReporter;
 
 // This method is called when your extension is activated
 // Your extension is activated the very first time the command is executed
 export async function activate(context: vscode.ExtensionContext) {
 	console.log('Congratulations, your extension "azure-ai-speech-toolkit" is now active!');
 
-	telemetryReporter = new TelemetryReporter(extensionPackage.name, extensionPackage.version, extensionPackage.aiKey);
-	context.subscriptions.push(telemetryReporter);
+	context.subscriptions.push(new ExtTelemetry.Reporter(context));
+	await ExtTelemetry.sendCachedTelemetryEventsAsync();
 
 	VS_CODE_UI = new VSCodeUI(TerminalName);
 	initializeGlobalVariables(context);
@@ -104,5 +102,5 @@ function activateSpeechFxRegistration(context: vscode.ExtensionContext) {
 
 // This method is called when your extension is deactivated
 export async function deactivate() {
-	await telemetryReporter.dispose();
+	await ExtTelemetry.dispose();
  }

--- a/azure-ai-speech-toolkit/src/telemetry/extTelemetry.ts
+++ b/azure-ai-speech-toolkit/src/telemetry/extTelemetry.ts
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import * as vscode from "vscode";
+import * as extensionPackage from "../../package.json";
+import TelemetryReporter from '@vscode/extension-telemetry';
+import { globalStateGet, globalStateUpdate } from "./extTelemetryCache";
+
+const TelemetryCacheKey = "TelemetryEvents";
+
+export namespace ExtTelemetry {
+  export let reporter: TelemetryReporter;
+
+  export class Reporter extends vscode.Disposable {
+    constructor(ctx: vscode.ExtensionContext) {
+      super(() => reporter.dispose());
+
+      reporter = new TelemetryReporter(
+        extensionPackage.name,
+        extensionPackage.version,
+        extensionPackage.aiKey
+      );
+    }
+  }
+
+  export function sendTelemetryEvent(
+    eventName: string,
+    properties?: { [p: string]: string },
+    measurements?: { [p: string]: number }
+  ): void {
+    reporter.sendTelemetryEvent(eventName, properties, measurements);
+  }
+
+  export async function cacheTelemetryEventAsync(
+    eventName: string,
+    properties?: { [p: string]: string }
+  ) {
+    const telemetryEvents = {
+      eventName: eventName,
+      properties: properties
+    };
+    const newValue = JSON.stringify(telemetryEvents);
+    await globalStateUpdate(TelemetryCacheKey, newValue);
+  }
+
+  export async function sendCachedTelemetryEventsAsync() {
+    const existingValue = (await globalStateGet(TelemetryCacheKey)) as string | undefined;
+    if (existingValue) {
+      try {
+        const telemetryEvent = JSON.parse(existingValue) as {
+          eventName: string;
+          properties: { [p: string]: string } | undefined;
+        };
+        reporter.sendTelemetryEvent(telemetryEvent.eventName, telemetryEvent.properties);
+      } catch (e) {}
+      await globalStateUpdate(TelemetryCacheKey, undefined);
+    }
+  }
+
+  export async function dispose() {
+    await reporter.dispose();
+  }
+}

--- a/azure-ai-speech-toolkit/src/telemetry/extTelemetryCache.ts
+++ b/azure-ai-speech-toolkit/src/telemetry/extTelemetryCache.ts
@@ -1,0 +1,113 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import * as os from "os";
+import * as path from "path";
+import * as fs from "fs-extra";
+import * as crypto from "crypto";
+import * as properLock from "proper-lockfile";
+
+const GlobalStateFileName = "state.json";
+const TelemetryCacheFolderName = "TelemetryCache";
+const productName = "azure-ai-speech-toolkit";
+
+/**
+ * Return a value.
+ *
+ * @param key A string.
+ * @return The stored value or `undefined`.
+ */
+export async function globalStateGet(key: string, defaultValue?: any): Promise<any> {
+  const filePath = getGlobalStateFile();
+  ensureGlobalStateFileExists(filePath);
+
+  const lockFileDir = getLockFolder(filePath);
+  const lockfilePath = path.join(lockFileDir, `${TelemetryCacheFolderName}.lock`);
+  await fs.ensureDir(lockFileDir);
+
+  const retryNum = 10;
+  for (let i = 0; i < retryNum; ++i) {
+    try {
+      await properLock.lock(filePath, { lockfilePath: lockfilePath });
+      let value: any = undefined;
+      try {
+        const config = await fs.readJSON(filePath);
+        value = config[key];
+        if (value === undefined) {
+          value = defaultValue;
+        }
+      } finally {
+        await properLock.unlock(filePath, { lockfilePath: lockfilePath });
+      }
+      return value;
+    } catch (e) {
+      if (e instanceof Object && "code" in e && e["code"] === "ELOCKED") {
+        await waitSeconds(1);
+        continue;
+      }
+      return undefined;
+    }
+  }
+}
+
+/**
+ * Store a value. The value must be JSON-stringifyable.
+ *
+ * @param key A string.
+ * @param value A value. MUST not contain cyclic references.
+ */
+export async function globalStateUpdate(key: string, value: any): Promise<void> {
+  const filePath = getGlobalStateFile();
+  ensureGlobalStateFileExists(filePath);
+
+  const lockFileDir = getLockFolder(filePath);
+  const lockfilePath = path.join(lockFileDir, `${TelemetryCacheFolderName}.lock`);
+  await fs.ensureDir(lockFileDir);
+
+  const retryNum = 10;
+  for (let i = 0; i < retryNum; ++i) {
+    try {
+      await properLock.lock(filePath, { lockfilePath: lockfilePath });
+      try {
+        const config = await fs.readJSON(filePath);
+        config[key] = value;
+        await fs.writeJson(filePath, config);
+      } finally {
+        await properLock.unlock(filePath, { lockfilePath: lockfilePath });
+      }
+      break;
+    } catch (e) {
+      if (e instanceof Object && "code" in e && e["code"] === "ELOCKED") {
+        await waitSeconds(1);
+        continue;
+      }
+      throw e;
+    }
+  }
+}
+
+function getGlobalStateFile(): string {
+  const homeDir = os.homedir();
+  return path.join(homeDir, `.${TelemetryCacheFolderName}`, GlobalStateFileName);
+}
+
+function ensureGlobalStateFileExists(filePath: string): void {
+  if (!fs.pathExistsSync(path.dirname(filePath))) {
+    fs.mkdirpSync(path.dirname(filePath));
+  }
+
+  if (!fs.existsSync(filePath)) {
+    fs.writeJSONSync(filePath, {});
+  }
+}
+
+function getLockFolder(projectPath: string): string {
+  return path.join(
+    os.tmpdir(),
+    `${productName}-${crypto.createHash("sha256").update(projectPath).digest("hex")}`
+  );
+}
+
+export async function waitSeconds(second: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, second * 1000));
+  }

--- a/azure-ai-speech-toolkit/src/telemetry/extTelemetryEvents.ts
+++ b/azure-ai-speech-toolkit/src/telemetry/extTelemetryEvents.ts
@@ -3,6 +3,7 @@
 
 export enum TelemetryEvent {
   AzureLogin = "azure-login",
+  DownloadSample = "download-sample",
   BuildSample = "build-sample",
   RunSample = "run-sample"
 }
@@ -13,6 +14,10 @@ export enum AzureLoginTelemetryProperty {
   AzureSubscriptionId = "oid",
   AzureTenantId = "tid",
   Email = "upn"
+}
+
+export enum DownloadSampleTelemetryProperty {
+  SAMPLE_ID = "sample-id"
 }
 
 export enum BuildAndRunSampleTelemetryProperty {

--- a/azure-ai-speech-toolkit/src/telemetry/extTelemetryUtils.ts
+++ b/azure-ai-speech-toolkit/src/telemetry/extTelemetryUtils.ts
@@ -3,7 +3,7 @@
 
 import * as fs from 'fs';
 import * as yaml from 'js-yaml';
-import { AzureLoginTelemetryProperty, BuildAndRunSampleTelemetryProperty } from "../telemetry/extTelemetryEvents";
+import { DownloadSampleTelemetryProperty, AzureLoginTelemetryProperty, BuildAndRunSampleTelemetryProperty } from "../telemetry/extTelemetryEvents";
 import { AzureAccountManager } from "../common/azureLogin";
 
 export async function getAzureUserTelemetryProperties(): Promise<{ [p: string]: string }> {
@@ -42,8 +42,8 @@ export function getSampleId(ymlFilePath: string) {
     return data.name;
 }
 
-// export async function getDownloadSampleTelemetryProperties(sampleId: string): Promise<{ [p: string]: string }> {
-//     const properties = await getAzureUserTelemetryProperties();
-//     properties[TelemetryDownloadSampleProperty.SampleId] = sampleId;
-//     return properties;
-// }
+export async function getDownloadSampleTelemetryProperties(sampleId: string): Promise<{ [p: string]: string }> {
+    const properties = await getAzureUserTelemetryProperties();
+    properties[DownloadSampleTelemetryProperty.SAMPLE_ID] = sampleId;
+    return properties;
+}


### PR DESCRIPTION
When download sample, we switch to sample folder as soon as download complete. This causes our extension deactivated and download-sample telemetry object been disposed, telemetry didn't get sent successfully.

This PR implement a cache mechanism that caches the download sample telemetry in local first, send cached telemetry when switch to sample folder and extension activate again. Make sure we don't lose any data