### PR TITLE
[Telemetry] add file existing check

### DIFF
--- a/azure-ai-speech-toolkit/src/telemetry/extTelemetryEvents.ts
+++ b/azure-ai-speech-toolkit/src/telemetry/extTelemetryEvents.ts
@@ -12,7 +12,7 @@ export enum DownloadSampleTelemetryProperty {
   SAMPLE_ID = "sample-id"
 }
 
-export enum BuildAndRunSampleTelemetryProperty {
+export enum SampleTaskTelemetryProperty {
   SUCCESS = "success",
   AZURE_SUBSCRIPTION_ID = "azure-subscription-id",
   SPEECH_RESOURCE_NAME = "speech-resource-name",

--- a/azure-ai-speech-toolkit/src/telemetry/extTelemetryUtils.ts
+++ b/azure-ai-speech-toolkit/src/telemetry/extTelemetryUtils.ts
@@ -3,15 +3,15 @@
 
 import * as fs from 'fs';
 import * as yaml from 'js-yaml';
-import { BuildAndRunSampleTelemetryProperty } from "../telemetry/extTelemetryEvents";
+import { SampleTaskTelemetryProperty } from "../telemetry/extTelemetryEvents";
 
-export function getBuildAndRunProperties(envfilePath: string): { [p: string]: string } {
+export function getSampleTaskTelemetryProperties(envfilePath: string): { [p: string]: string } {
     const content = fs.readFileSync(envfilePath, 'utf-8');
     const lines = content.split('\n');
     const properties: { [p: string]: string } = {};
     lines.forEach(line => {
         const [key, value] = line.split('=').map(part => part.trim());
-        if (key && value && key in BuildAndRunSampleTelemetryProperty) {
+        if (key && value && key in SampleTaskTelemetryProperty) {
             properties[key] = value;
         }
     });


### PR DESCRIPTION
Fix a bug for telemetry. Avoid service error when user execute build/run tasks before set their environment file.
Also some variable renaming