### PR TITLE
Update TelemetryEvents and Property

### DIFF
--- a/azure-ai-speech-toolkit/src/telemetry/extTelemetryEvents.ts
+++ b/azure-ai-speech-toolkit/src/telemetry/extTelemetryEvents.ts
@@ -2,19 +2,28 @@
 // Licensed under the MIT license.
 
 export enum TelemetryEvent {
+  AZURE_LOGIN = "azure-login",
   DOWNLOAD_SAMPLE = "download-sample",
   CONFIGURE_AND_SETUP_SAMPLE = "configure-and-setup-sample",
   BUILD_SAMPLE = "build-sample",
   RUN_SAMPLE = "run-sample"
 }
 
+export enum AzureLoginTelemetryProperty {
+  SUCCESS = "success",
+  ERROR_MESSAGE = "error_message"
+}
+
 export enum DownloadSampleTelemetryProperty {
-  SAMPLE_ID = "sample-id"
+  SUCCESS = "success",
+  ERROR_MESSAGE = "error_message",
+  SAMPLE_ID = "sample_id",
 }
 
 export enum SampleTaskTelemetryProperty {
   SUCCESS = "success",
-  AZURE_SUBSCRIPTION_ID = "azure-subscription-id",
-  SPEECH_RESOURCE_NAME = "speech-resource-name",
-  SAMPLE_ID = "sample-id"
+  ERROR_MESSAGE = "error_message",
+  AZURE_SUBSCRIPTION_ID = "azure_subscription_id",
+  SPEECH_RESOURCE_NAME = "speech_resource_name",
+  SAMPLE_ID = "sample_id"
 }

--- a/azure-ai-speech-toolkit/src/telemetry/extTelemetryUtils.ts
+++ b/azure-ai-speech-toolkit/src/telemetry/extTelemetryUtils.ts
@@ -3,7 +3,7 @@
 
 import * as fs from 'fs';
 import * as yaml from 'js-yaml';
-import { SampleTaskTelemetryProperty } from "../telemetry/extTelemetryEvents";
+import * as TelemetryEvent from "../telemetry/extTelemetryEvents";
 
 export function getSampleTaskTelemetryProperties(envfilePath: string): { [p: string]: string } {
     const content = fs.readFileSync(envfilePath, 'utf-8');
@@ -11,7 +11,7 @@ export function getSampleTaskTelemetryProperties(envfilePath: string): { [p: str
     const properties: { [p: string]: string } = {};
     lines.forEach(line => {
         const [key, value] = line.split('=').map(part => part.trim());
-        if (key && value && key in SampleTaskTelemetryProperty) {
+        if (key && value && key in TelemetryEvent.SampleTaskTelemetryProperty) {
             properties[key] = value;
         }
     });
@@ -24,3 +24,15 @@ export function getSampleId(ymlFilePath: string) {
     const data = yaml.load(fileContents) as { name: string; version: string };  
     return data.name;
 }
+
+export function getAzureLoginProperties(success: boolean, errorMessage: any): { [key: string]: string } {  
+    const properties: { [key: string]: string } = {  
+        [TelemetryEvent.AzureLoginTelemetryProperty.SUCCESS]: success.toString()  
+    };  
+  
+    if (!success) {  
+        properties[TelemetryEvent.AzureLoginTelemetryProperty.ERROR_MESSAGE] = typeof errorMessage === 'string' && errorMessage.trim() !== '' ? errorMessage : "Unknown";  
+    }  
+  
+    return properties;  
+}  


### PR DESCRIPTION
This PR did following changes
1. Update some TelemetryProperties, use '_' instead of '-'
2. Add azure-login telemetry event 
3. (Not included in code) Classified build-sample event, we should be able to see build-sample event in data explorer after this change