### PR TITLE
fix: create vscode session if none when getting subscriptions

### DIFF
--- a/azure-ai-speech-toolkit/src/extension.ts
+++ b/azure-ai-speech-toolkit/src/extension.ts
@@ -5,7 +5,7 @@ import { CommandKeys, ContextKeys, TaskName, TerminalName, VSCodeCommands } from
 import * as handlers from "./handlers";
 import { initializeGlobalVariables, isSpeechFxProject } from './globalVariables';
 import { VSCodeUI } from './ui/ui';
-import accountTreeViewProviderInstance from "./treeview/account/accountTreeViewProvider";
+// import accountTreeViewProviderInstance from "./treeview/account/accountTreeViewProvider";
 import { AzureAccountManager } from './common/azureLogin';
 import TreeViewManagerInstance from "./treeview/treeViewManager";
 import { isSpeechResourceSeleted } from './utils';
@@ -107,9 +107,9 @@ export async function activate(context: vscode.ExtensionContext) {
 async function activateResourceTreeRegistration(context: vscode.ExtensionContext) {
 	TreeViewManagerInstance.registerTreeViews(context);
 
-	accountTreeViewProviderInstance.subscribeToStatusChanges({
-		azureAccountProvider: AzureAccountManager.getInstance(),
-	});
+	// accountTreeViewProviderInstance.subscribeToStatusChanges({
+	// 	azureAccountProvider: AzureAccountManager.getInstance(),
+	// });
 
 	resourceTreeViewProvider.subscribeToStatusChanges({
 		azureAccountProvider: AzureAccountManager.getInstance(),

--- a/azure-ai-speech-toolkit/src/treeview/account/accountTreeViewProvider.ts
+++ b/azure-ai-speech-toolkit/src/treeview/account/accountTreeViewProvider.ts
@@ -1,109 +1,109 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT license.
 
-import * as vscode from "vscode";
+// import * as vscode from "vscode";
 
-import { TokenProvider } from "../../api/login";
-import { DynamicNode } from "../dynamicNode";
-import { AzureAccountNode } from "./azureNode";
+// import { TokenProvider } from "../../api/login";
+// import { DynamicNode } from "../dynamicNode";
+// import { AzureAccountNode } from "./azureNode";
 
-class AccountTreeViewProvider implements vscode.TreeDataProvider<DynamicNode> {
-  private static instance: AccountTreeViewProvider;
-  private _onDidChangeTreeData: vscode.EventEmitter<DynamicNode | undefined | void> =
-    new vscode.EventEmitter<DynamicNode | undefined | void>();
-  readonly onDidChangeTreeData: vscode.Event<DynamicNode | undefined | void> =
-    this._onDidChangeTreeData.event;
+// class AccountTreeViewProvider implements vscode.TreeDataProvider<DynamicNode> {
+//   private static instance: AccountTreeViewProvider;
+//   private _onDidChangeTreeData: vscode.EventEmitter<DynamicNode | undefined | void> =
+//     new vscode.EventEmitter<DynamicNode | undefined | void>();
+//   readonly onDidChangeTreeData: vscode.Event<DynamicNode | undefined | void> =
+//     this._onDidChangeTreeData.event;
 
-  public azureAccountNode = new AzureAccountNode(this._onDidChangeTreeData);
+//   public azureAccountNode = new AzureAccountNode(this._onDidChangeTreeData);
 
-  private constructor() {}
+//   private constructor() {}
 
-  public static getInstance() {
-    if (!AccountTreeViewProvider.instance) {
-      AccountTreeViewProvider.instance = new AccountTreeViewProvider();
-    }
-    return AccountTreeViewProvider.instance;
-  }
+//   public static getInstance() {
+//     if (!AccountTreeViewProvider.instance) {
+//       AccountTreeViewProvider.instance = new AccountTreeViewProvider();
+//     }
+//     return AccountTreeViewProvider.instance;
+//   }
 
-  public subscribeToStatusChanges(tokenProvider: TokenProvider) {
-    // void tokenProvider.m365TokenProvider?.setStatusChangeMap(
-    //   "tree-view",
-    //   { scopes: AppStudioScopes },
-    //   (status, token, accountInfo) =>
-    //     m365AccountStatusChangeHandler("appStudio", status, token, accountInfo)
-    // );
-    void tokenProvider.azureAccountProvider?.setStatusChangeMap(
-      "tree-view",
-      azureAccountStatusChangeHandler
-    );
-  }
+//   public subscribeToStatusChanges(tokenProvider: TokenProvider) {
+//     // void tokenProvider.m365TokenProvider?.setStatusChangeMap(
+//     //   "tree-view",
+//     //   { scopes: AppStudioScopes },
+//     //   (status, token, accountInfo) =>
+//     //     m365AccountStatusChangeHandler("appStudio", status, token, accountInfo)
+//     // );
+//     void tokenProvider.azureAccountProvider?.setStatusChangeMap(
+//       "tree-view",
+//       azureAccountStatusChangeHandler
+//     );
+//   }
 
-  public getTreeItem(element: DynamicNode): vscode.TreeItem | Promise<vscode.TreeItem> {
-    return element.getTreeItem();
-  }
+//   public getTreeItem(element: DynamicNode): vscode.TreeItem | Promise<vscode.TreeItem> {
+//     return element.getTreeItem();
+//   }
 
-  public getChildren(element?: DynamicNode): vscode.ProviderResult<DynamicNode[]> {
-    if (!element) {
-      return this.getAccountNodes();
-    }
-    return element.getChildren();
-  }
+//   public getChildren(element?: DynamicNode): vscode.ProviderResult<DynamicNode[]> {
+//     if (!element) {
+//       return this.getAccountNodes();
+//     }
+//     return element.getChildren();
+//   }
 
-  private getAccountNodes(): DynamicNode[] {
-    // if (isSPFxProject) {
-    //   return [this.m365AccountNode];
-    // } else {
-      return [/*this.m365AccountNode,*/ this.azureAccountNode];
-    // }
-  }
-}
+//   private getAccountNodes(): DynamicNode[] {
+//     // if (isSPFxProject) {
+//     //   return [this.m365AccountNode];
+//     // } else {
+//       return [/*this.m365AccountNode,*/ this.azureAccountNode];
+//     // }
+//   }
+// }
 
-// async function m365AccountStatusChangeHandler(
-//   source: string,
+// // async function m365AccountStatusChangeHandler(
+// //   source: string,
+// //   status: string,
+// //   token?: string | undefined,
+// //   accountInfo?: Record<string, unknown> | undefined
+// // ) {
+// //   const instance = AccountTreeViewProvider.getInstance();
+// //   if (status === "SignedIn") {
+// //     if (accountInfo) {
+// //       instance.m365AccountNode.setSignedIn(
+// //         (accountInfo.upn as string) ? (accountInfo.upn as string) : ""
+// //       );
+// //       if (token && source === "appStudio") {
+// //         instance.m365AccountNode.updateChecks(token, true, true);
+// //       }
+// //     }
+// //   } else if (status === "SigningIn") {
+// //     instance.m365AccountNode.setSigningIn();
+// //   } else if (status === "SignedOut") {
+// //     instance.m365AccountNode.setSignedOut();
+// //   } else if (status == "Switching") {
+// //     instance.m365AccountNode.setSwitching();
+// //   }
+// //   await envTreeProviderInstance.reloadEnvironments();
+// //   return Promise.resolve();
+// // }
+
+// async function azureAccountStatusChangeHandler(
 //   status: string,
 //   token?: string | undefined,
 //   accountInfo?: Record<string, unknown> | undefined
 // ) {
 //   const instance = AccountTreeViewProvider.getInstance();
 //   if (status === "SignedIn") {
-//     if (accountInfo) {
-//       instance.m365AccountNode.setSignedIn(
-//         (accountInfo.upn as string) ? (accountInfo.upn as string) : ""
-//       );
-//       if (token && source === "appStudio") {
-//         instance.m365AccountNode.updateChecks(token, true, true);
-//       }
+//     const username = (accountInfo?.email as string) || (accountInfo?.upn as string);
+//     if (username) {
+//       instance.azureAccountNode.setSignedIn(username);
+//       // await envTreeProviderInstance.reloadEnvironments();
 //     }
 //   } else if (status === "SigningIn") {
-//     instance.m365AccountNode.setSigningIn();
+//     instance.azureAccountNode.setSigningIn();
 //   } else if (status === "SignedOut") {
-//     instance.m365AccountNode.setSignedOut();
-//   } else if (status == "Switching") {
-//     instance.m365AccountNode.setSwitching();
+//     instance.azureAccountNode.setSignedOut();
+//     // await envTreeProviderInstance.reloadEnvironments();
 //   }
-//   await envTreeProviderInstance.reloadEnvironments();
 //   return Promise.resolve();
 // }
 
-async function azureAccountStatusChangeHandler(
-  status: string,
-  token?: string | undefined,
-  accountInfo?: Record<string, unknown> | undefined
-) {
-  const instance = AccountTreeViewProvider.getInstance();
-  if (status === "SignedIn") {
-    const username = (accountInfo?.email as string) || (accountInfo?.upn as string);
-    if (username) {
-      instance.azureAccountNode.setSignedIn(username);
-      // await envTreeProviderInstance.reloadEnvironments();
-    }
-  } else if (status === "SigningIn") {
-    instance.azureAccountNode.setSigningIn();
-  } else if (status === "SignedOut") {
-    instance.azureAccountNode.setSignedOut();
-    // await envTreeProviderInstance.reloadEnvironments();
-  }
-  return Promise.resolve();
-}
-
-export default AccountTreeViewProvider.getInstance();
+// export default AccountTreeViewProvider.getInstance();

--- a/azure-ai-speech-toolkit/src/treeview/treeViewManager.ts
+++ b/azure-ai-speech-toolkit/src/treeview/treeViewManager.ts
@@ -8,7 +8,7 @@ import { TreeCategory } from "../api/tree";
 import { /*isDeclarativeCopilotApp, isSPFxProject, */workspaceUri } from "../globalVariables";
 // import { hasAdaptiveCardInWorkspace } from "../utils/commonUtils";
 // import { localize } from "../utils/localizeUtils";
-import accountTreeViewProviderInstance from "./account/accountTreeViewProvider";
+// import accountTreeViewProviderInstance from "./account/accountTreeViewProvider";
 import { CommandsTreeViewProvider } from "./commandsTreeViewProvider";
 // import envTreeProviderInstance from "./environmentTreeViewProvider";
 import { CommandStatus, TreeViewCommand } from "./treeViewCommand";


### PR DESCRIPTION
Issue: #97 

For some azure account, the extension fails to fetch vscode session even after user successfully logged in. Enable `createIfNone` parameter so the extension will pop up windows asking user to grant authentication.